### PR TITLE
Add two links to projects page

### DIFF
--- a/__tests__/menu.test.js
+++ b/__tests__/menu.test.js
@@ -26,7 +26,10 @@ describe('Mobile Menu Functionality', () => {
     const scriptPath = path.resolve(__dirname, '../script.js');
     const scriptContent = fs.readFileSync(scriptPath, 'utf8');
     // Remove module.exports for browser context
-    const browserScript = scriptContent.replace(/if \(typeof module.*?\}/s, '');
+    const moduleExportMatch = scriptContent.match(/if \(typeof module[\s\S]*?module\.exports[\s\S]*?\n\}/);
+    const browserScript = moduleExportMatch
+      ? scriptContent.replace(moduleExportMatch[0], '')
+      : scriptContent;
     eval(browserScript);
   });
 

--- a/__tests__/projects.test.js
+++ b/__tests__/projects.test.js
@@ -1,0 +1,153 @@
+/**
+ * Projects Page Links Tests
+ *
+ * TDD: These tests are written BEFORE implementing the projects links functionality.
+ * This demonstrates the Red-Green-Refactor cycle:
+ * 1. RED: Write failing test that describes desired behavior
+ * 2. GREEN: Write minimal code to make test pass
+ * 3. REFACTOR: Improve code while keeping tests green
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+describe('Projects Page Links Functionality', () => {
+  let container;
+
+  beforeEach(() => {
+    // Load HTML file
+    const html = fs.readFileSync(
+      path.resolve(__dirname, '../index.html'),
+      'utf8'
+    );
+    document.documentElement.innerHTML = html;
+
+    // Load and execute script
+    const scriptPath = path.resolve(__dirname, '../script.js');
+    const scriptContent = fs.readFileSync(scriptPath, 'utf8');
+    // Remove module.exports for browser context
+    const moduleExportMatch = scriptContent.match(/if \(typeof module[\s\S]*?module\.exports[\s\S]*?\n\}/);
+    const browserScript = moduleExportMatch
+      ? scriptContent.replace(moduleExportMatch[0], '')
+      : scriptContent;
+    eval(browserScript);
+  });
+
+  afterEach(() => {
+    document.documentElement.innerHTML = '';
+  });
+
+  describe('Projects Section and Links Exist', () => {
+    test('projects section exists with correct ID', () => {
+      const projectsSection = document.getElementById('projects');
+      expect(projectsSection).toBeInTheDocument();
+      expect(projectsSection.tagName).toBe('SECTION');
+    });
+
+    test('projects links container exists', () => {
+      const projectsLinks = document.querySelector('.projects-links');
+      expect(projectsLinks).toBeInTheDocument();
+    });
+
+    test('F5 projects link exists with correct text', () => {
+      const f5Link = document.querySelector('.project-link-left');
+      expect(f5Link).toBeInTheDocument();
+      expect(f5Link.textContent).toBe('F5 projects');
+      expect(f5Link.tagName).toBe('A');
+    });
+
+    test('Personal projects link exists with correct text', () => {
+      const personalLink = document.querySelector('.project-link-right');
+      expect(personalLink).toBeInTheDocument();
+      expect(personalLink.textContent).toBe('personal projects');
+      expect(personalLink.tagName).toBe('A');
+    });
+  });
+
+  describe('Projects Links Visibility Toggle', () => {
+    test('projects links are hidden by default', () => {
+      const projectsLinks = document.querySelector('.projects-links');
+      expect(projectsLinks.classList.contains('active')).toBe(false);
+    });
+
+    test('clicking Projects nav link shows project links', () => {
+      const projectsNavLink = document.querySelector('a[href="#projects"]');
+      const projectsLinks = document.querySelector('.projects-links');
+
+      // Initially hidden
+      expect(projectsLinks.classList.contains('active')).toBe(false);
+
+      // Click projects link
+      projectsNavLink.click();
+
+      // Should now be visible
+      expect(projectsLinks.classList.contains('active')).toBe(true);
+    });
+
+    test('clicking Projects nav link hides other section phrases', () => {
+      const projectsNavLink = document.querySelector('a[href="#projects"]');
+      const aboutMePhrases = document.querySelector('.about-me-phrases');
+      const hobbiesPhrases = document.querySelector('.hobbies-phrases');
+
+      // Activate about me phrases first
+      aboutMePhrases.classList.add('active');
+      hobbiesPhrases.classList.add('active');
+
+      // Click projects link
+      projectsNavLink.click();
+
+      // Other phrases should be hidden
+      expect(aboutMePhrases.classList.contains('active')).toBe(false);
+      expect(hobbiesPhrases.classList.contains('active')).toBe(false);
+    });
+
+    test('clicking Projects link toggles visibility', () => {
+      const projectsNavLink = document.querySelector('a[href="#projects"]');
+      const projectsLinks = document.querySelector('.projects-links');
+
+      // First click shows links
+      projectsNavLink.click();
+      expect(projectsLinks.classList.contains('active')).toBe(true);
+
+      // Second click hides links
+      projectsNavLink.click();
+      expect(projectsLinks.classList.contains('active')).toBe(false);
+    });
+
+    test('clicking Projects in mobile sidebar also shows project links', () => {
+      const projectsSidebarLink = document.querySelector('.sidebar-link[href="#projects"]');
+      const projectsLinks = document.querySelector('.projects-links');
+
+      // Initially hidden
+      expect(projectsLinks.classList.contains('active')).toBe(false);
+
+      // Click projects sidebar link
+      projectsSidebarLink.click();
+
+      // Should now be visible
+      expect(projectsLinks.classList.contains('active')).toBe(true);
+    });
+  });
+
+  describe('Projects Links Positioning', () => {
+    test('projects links container exists with correct class', () => {
+      const projectsLinks = document.querySelector('.projects-links');
+      expect(projectsLinks).toBeInTheDocument();
+      expect(projectsLinks.classList.contains('projects-links')).toBe(true);
+    });
+
+    test('F5 projects link is positioned on left side', () => {
+      const f5Link = document.querySelector('.project-link-left');
+      const styles = window.getComputedStyle(f5Link);
+      // Left positioned link should not have right alignment
+      expect(styles.left).not.toBe('auto');
+    });
+
+    test('Personal projects link is positioned on right side', () => {
+      const personalLink = document.querySelector('.project-link-right');
+      const styles = window.getComputedStyle(personalLink);
+      // Right positioned link should not have left alignment
+      expect(styles.right).not.toBe('auto');
+    });
+  });
+});

--- a/index.html
+++ b/index.html
@@ -30,6 +30,12 @@
         <span class="phrase">volleyball</span>
     </div>
 
+    <!-- Projects Links -->
+    <div class="projects-links">
+        <a href="#f5-projects" class="project-link-left">F5 projects</a>
+        <a href="#personal-projects" class="project-link-right">personal projects</a>
+    </div>
+
     <!-- Navigation Bar -->
     <nav class="top-nav">
         <a href="#about" class="nav-link">About Me</a>
@@ -67,9 +73,21 @@
         </div>
     </section>
 
+    <section id="projects" class="content-section">
+        <div class="content-card">
+            <h2>Projects</h2>
+        </div>
+    </section>
+
     <section id="hobbies" class="content-section">
         <div class="content-card">
             <h2>Hobbies</h2>
+        </div>
+    </section>
+
+    <section id="resume" class="content-section">
+        <div class="content-card">
+            <h2>Resume</h2>
         </div>
     </section>
 

--- a/script.js
+++ b/script.js
@@ -44,8 +44,9 @@ const aboutMePhrases = document.querySelector('.about-me-phrases');
 const aboutMeLinks = document.querySelectorAll('a[href="#about"]');
 
 function toggleAboutMePhrases(event) {
-    // Hide hobbies phrases first to prevent overlap
+    // Hide hobbies phrases and projects links first to prevent overlap
     hobbiesPhrases.classList.remove('active');
+    projectsLinks.classList.remove('active');
 
     // Toggle the visibility of phrases
     aboutMePhrases.classList.toggle('active');
@@ -64,8 +65,9 @@ const hobbiesPhrases = document.querySelector('.hobbies-phrases');
 const hobbiesLinks = document.querySelectorAll('a[href="#hobbies"]');
 
 function toggleHobbiesPhrases(event) {
-    // Hide about me phrases first to prevent overlap
+    // Hide about me phrases and projects links first to prevent overlap
     aboutMePhrases.classList.remove('active');
+    projectsLinks.classList.remove('active');
 
     // Toggle the visibility of phrases
     hobbiesPhrases.classList.toggle('active');
@@ -79,12 +81,34 @@ hobbiesLinks.forEach(link => {
     link.addEventListener('click', toggleHobbiesPhrases);
 });
 
+// Projects links toggle
+const projectsLinks = document.querySelector('.projects-links');
+const projectsNavLinks = document.querySelectorAll('a[href="#projects"]');
+
+function toggleProjectsLinks(event) {
+    // Hide about me and hobbies phrases first to prevent overlap
+    aboutMePhrases.classList.remove('active');
+    hobbiesPhrases.classList.remove('active');
+
+    // Toggle the visibility of projects links
+    projectsLinks.classList.toggle('active');
+
+    // Prevent default scroll behavior when toggling
+    event.preventDefault();
+}
+
+// Add click listeners to all Projects links (desktop and mobile)
+projectsNavLinks.forEach(link => {
+    link.addEventListener('click', toggleProjectsLinks);
+});
+
 // Export functions for testing
 if (typeof module !== 'undefined' && module.exports) {
     module.exports = {
         openSidebar,
         closeSidebar,
         toggleAboutMePhrases,
-        toggleHobbiesPhrases
+        toggleHobbiesPhrases,
+        toggleProjectsLinks
     };
 }

--- a/styles.css
+++ b/styles.css
@@ -109,6 +109,78 @@ body {
     text-shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
 }
 
+/* Projects Links - Sky Section Layout */
+.projects-links {
+    position: fixed;
+    top: 15%;
+    left: 0;
+    right: 0;
+    z-index: 100;
+    pointer-events: none;
+
+    /* Hidden by default */
+    opacity: 0;
+    visibility: hidden;
+    transition: opacity 0.6s ease, visibility 0.6s ease;
+}
+
+.projects-links.active {
+    opacity: 1;
+    visibility: visible;
+}
+
+/* Project Link Base Styling with Glassmorphism */
+.projects-links a {
+    position: absolute;
+    top: 0;
+    pointer-events: auto;
+
+    /* Glassmorphism Effect */
+    background: rgba(255, 255, 255, 0.15);
+    backdrop-filter: blur(10px);
+    -webkit-backdrop-filter: blur(10px);
+
+    /* Styling */
+    padding: 16px 32px;
+    border-radius: 50px;
+    border: 1px solid rgba(255, 255, 255, 0.3);
+    box-shadow: 0 8px 32px 0 rgba(0, 0, 0, 0.2);
+
+    /* Typography */
+    font-family: 'Poppins', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+    font-size: 20px;
+    font-weight: 500;
+    color: rgba(255, 255, 255, 0.95);
+    text-decoration: none;
+    letter-spacing: 0.5px;
+
+    /* Animation */
+    transition: all 0.3s ease;
+}
+
+/* F5 Projects - Left Side */
+.project-link-left {
+    left: 40px;
+}
+
+/* Personal Projects - Right Side */
+.project-link-right {
+    right: 40px;
+}
+
+/* Hover Effect */
+.projects-links a:hover {
+    background: rgba(255, 255, 255, 0.25);
+    transform: translateY(-2px);
+    box-shadow: 0 12px 40px 0 rgba(0, 0, 0, 0.3);
+    color: #ffffff;
+}
+
+/* Active/Focus State */
+.projects-links a:active {
+    transform: translateY(0);
+}
+
 /* Glassmorphism Navigation Bar */
 .top-nav {
     position: fixed;
@@ -426,6 +498,24 @@ body {
     .hobbies-phrases .phrase {
         font-size: 24px;
     }
+
+    /* Responsive Projects Links */
+    .projects-links {
+        top: 12%;
+    }
+
+    .projects-links a {
+        font-size: 16px;
+        padding: 12px 24px;
+    }
+
+    .project-link-left {
+        left: 20px;
+    }
+
+    .project-link-right {
+        right: 20px;
+    }
 }
 
 /* Smooth Scrolling */
@@ -441,6 +531,11 @@ html {
 
 #about .content-card {
     display: none; /* Hide the placeholder card on hero section */
+}
+
+/* Hide Projects Content Card (uses interactive links instead) */
+#projects .content-card {
+    display: none;
 }
 
 /* Hide Hobbies Content Card (uses interactive phrases instead) */


### PR DESCRIPTION
Following TDD approach, implemented new projects section with:
- Two clickable links in sky section ("F5 projects" left, "personal projects" right)
- Glassmorphism design pattern matching site aesthetic
- Toggle functionality to show/hide links when Projects nav is clicked
- Responsive styling for mobile devices
- JavaScript to prevent overlap with About Me and Hobbies sections
- Comprehensive test coverage (12 tests all passing)

Also added:
- Resume section placeholder to match navigation structure
- Fixed regex pattern in menu.test.js for better compatibility