### PR TITLE
Remove resume navigation and popup

### DIFF
--- a/__tests__/dom.test.js
+++ b/__tests__/dom.test.js
@@ -72,7 +72,7 @@ describe('DOM Structure and Elements', () => {
       expect(links.length).toBe(4);
 
       const hrefs = Array.from(links).map(link => link.getAttribute('href'));
-      expect(hrefs).toEqual(['#about', '#projects', '#hobbies', '#resume']);
+      expect(hrefs).toEqual(['#about', '#projects', '#hobbies', 'javascript:void(0)']);
 
       const texts = Array.from(links).map(link => link.textContent);
       expect(texts).toEqual(['About Me', 'Projects', 'Hobbies', 'Resume']);
@@ -122,7 +122,7 @@ describe('DOM Structure and Elements', () => {
       expect(links.length).toBe(4);
 
       const hrefs = Array.from(links).map(link => link.getAttribute('href'));
-      expect(hrefs).toEqual(['#about', '#projects', '#hobbies', '#resume']);
+      expect(hrefs).toEqual(['#about', '#projects', '#hobbies', 'javascript:void(0)']);
     });
   });
 

--- a/index.html
+++ b/index.html
@@ -44,7 +44,7 @@
         <span class="nav-separator">•</span>
         <a href="#hobbies" class="nav-link">Hobbies</a>
         <span class="nav-separator">•</span>
-        <a href="#resume" class="nav-link">Resume</a>
+        <a href="javascript:void(0)" class="nav-link">Resume</a>
     </nav>
 
     <!-- Mobile Hamburger Icon -->
@@ -62,7 +62,7 @@
             <a href="#about" class="sidebar-link">About Me</a>
             <a href="#projects" class="sidebar-link">Projects</a>
             <a href="#hobbies" class="sidebar-link">Hobbies</a>
-            <a href="#resume" class="sidebar-link">Resume</a>
+            <a href="javascript:void(0)" class="sidebar-link">Resume</a>
         </div>
     </nav>
 

--- a/styles.css
+++ b/styles.css
@@ -517,3 +517,8 @@ html {
 #projects .content-card {
     display: none;
 }
+
+/* Hide Resume Content Card (no action on click) */
+#resume .content-card {
+    display: none;
+}


### PR DESCRIPTION
Fixes #6

This PR removes the popup/box that appears when clicking on "Resume" in the navigation. Nothing now happens when the Resume link is clicked.

## Changes
- Changed resume link href to `javascript:void(0)` to prevent navigation
- Added CSS to hide resume content card
- Updated tests to reflect the change

Generated with [Claude Code](https://claude.ai/code)